### PR TITLE
Refactor App.ts to use private _invoke property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/ts-cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "files": [
     "dist",

--- a/src/App.ts
+++ b/src/App.ts
@@ -17,7 +17,7 @@ export class App<
     }
   >
 > {
-  readonly invoke
+  private readonly _invoke
 
   constructor(
     private readonly config: RC,
@@ -27,12 +27,16 @@ export class App<
     this.config = config
     this.handler = handler
     this.routes = routes
-    this.invoke = transform(routes, ([route, { config, handler }]) => [
+    this._invoke = transform(routes, ([route, { config, handler }]) => [
       route,
       (param: InvokeParam<Config>) => handler(param, config)
     ]) as {
       [K in keyof RT]: InvokeHandler<RT[K]['config']>
     }
+  }
+
+  get invoke() {
+    return this._invoke
   }
 
   add<T extends string, C extends Config, H extends InvokeHandler<C>>(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the access level of the `invoke` property in the application to enhance encapsulation. Users can now access it via a public getter method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->